### PR TITLE
template: replace unpkg w/ jsdelivr

### DIFF
--- a/packages/magic/src/default-assets.ts
+++ b/packages/magic/src/default-assets.ts
@@ -1,16 +1,16 @@
 import type {ScriptData, StyleData} from "./types";
 
 export const scripts: Record<string, ScriptData> = {
-  host: "https://unpkg.com/@liqvid/host/lv-host.js",
+  host: "https://cdn.jsdelivr.net/npm/@liqvid/host/lv-host.js",
   liqvid: {
     crossorigin: true,
-    development: "https://unpkg.com/liqvid@2.1.4/dist/liqvid.js",
-    production: "https://unpkg.com/liqvid@2.1.4/dist/liqvid.min.js",
+    development: "https://cdn.jsdelivr.net/npm/liqvid@2.1.4/dist/liqvid.js",
+    production: "https://cdn.jsdelivr.net/npm/liqvid@2.1.4/dist/liqvid.min.js",
     integrity:
       "sha384-o8Svf9aNpbI8MzaCkJ0rPo5OxnnZ9Zf86Z18azwsy6rPuenc22zYvNwyv49wIgWa",
   },
   livereload: {},
-  polyfills: "https://unpkg.com/@liqvid/polyfills/dist/waapi.js",
+  polyfills: "https://cdn.jsdelivr.net/npm/@liqvid/polyfills/dist/waapi.js",
   rangetouch: {
     crossorigin: true,
     development: "https://cdn.rangetouch.com/2.0.1/rangetouch.js",
@@ -20,29 +20,29 @@ export const scripts: Record<string, ScriptData> = {
   },
   react: {
     crossorigin: true,
-    development: "https://unpkg.com/react@17.0.2/umd/react.development.js",
-    production: "https://unpkg.com/react@17.0.2/umd/react.production.min.js",
+    development: "https://cdn.jsdelivr.net/npm/react@17.0.2/umd/react.development.js",
+    production: "https://cdn.jsdelivr.net/npm/react@17.0.2/umd/react.production.min.js",
     integrity:
       "sha384-7Er69WnAl0+tY5MWEvnQzWHeDFjgHSnlQfDDeWUvv8qlRXtzaF/pNo18Q2aoZNiO",
   },
   "react-dom": {
     crossorigin: true,
     development:
-      "https://unpkg.com/react-dom@17.0.2/umd/react-dom.development.js",
+      "https://cdn.jsdelivr.net/npm/react-dom@17.0.2/umd/react-dom.development.js",
     production:
-      "https://unpkg.com/react-dom@17.0.2/umd/react-dom.production.min.js",
+      "https://cdn.jsdelivr.net/npm/react-dom@17.0.2/umd/react-dom.production.min.js",
     integrity:
       "sha384-vj2XpC1SOa8PHrb0YlBqKN7CQzJYO72jz4CkDQ+ePL1pwOV4+dn05rPrbLGUuvCv",
   },
   recording: {
     crossorigin: true,
-    development: "https://unpkg.com/rp-recording@2.1.1/dist/rp-recording.js",
+    development: "https://cdn.jsdelivr.net/npm/rp-recording@2.1.1/dist/rp-recording.js",
   },
 };
 
 export const styles: Record<string, StyleData> = {
   liqvid: {
-    development: "https://unpkg.com/liqvid@2.1.4/dist/liqvid.css",
-    production: "https://unpkg.com/liqvid@2.1.4/dist/liqvid.min.css",
+    development: "https://cdn.jsdelivr.net/npm/liqvid@2.1.4/dist/liqvid.css",
+    production: "https://cdn.jsdelivr.net/npm/liqvid@2.1.4/dist/liqvid.min.css",
   },
 };


### PR DESCRIPTION
UNPKG has not been actively maintained and has been down since `Mar 15, 2025` (https://github.com/unpkg/unpkg/issues/412).

The PR replaces UNPKG usage inside the template's config with jsDelivr.